### PR TITLE
Fix for `[ab]+c ~ [bc]+` cases

### DIFF
--- a/non_empty.go
+++ b/non_empty.go
@@ -102,12 +102,17 @@ func intersectSpecial(g1, g2 Glob) bool {
 
 // intersectPlus accepts two globs such that plussed[0].Flag() == FlagPlus.
 // It returns a boolean describing whether their intersection exists.
-// It ensures that at least one token in other maches plussed[0], before handing flow of control to intersectSpecial.
+// It ensures that at least one token in other maches plussed[0].
 func intersectPlus(plussed, other Glob) bool {
 	if !Match(plussed[0], other[0]) {
 		return false
 	}
-	return intersectStar(plussed, other[1:])
+	// Either the plussed has gobbled up other[0]...
+	if intersectStar(plussed, other[1:]) {
+		return true
+	}
+	// ...or if other[0] has a flag, it may completely gobble up plussed[0].
+	return other[0].Flag() != FlagNone && intersectNormal(plussed[1:], other)
 }
 
 // intersectStar accepts two globs such that starred[0].Flag() == FlagStar.

--- a/non_empty_test.go
+++ b/non_empty_test.go
@@ -6,16 +6,17 @@ import (
 
 func TestNonEmptyIntersections(t *testing.T) {
 	tests := map[string][]string{
-		"abcd":        []string{"abcd", "....", "[a-d]*"},
-		"pqrs":        []string{".qrs", "p.rs", "pq.s", "pqr."},
-		".*":          []string{"asdklfj", "jasdfh", "asdhfajfh", "asdflkasdfjl"},
-		"d*":          []string{"[abcd][abcd]", "d[a-z]+", ".....", "[d]*"},
-		"[a-p]+":      []string{"[p-z]+", "apapapaapapapap", ".*", "abcdefgh*"},
-		"abcd[a-c]z+": []string{"abcd[b-d][yz]*", "abcdazzzz", "abcdbzzz", "abcdcz"},
-		".*\\\\":      []string{".*", "asdfasdf\\\\"}, // Escaped \ character.
-		".a.a":        []string{"b.b.", "c.c.", "d.d.", "e.e."},
+		"abcd":                           []string{"abcd", "....", "[a-d]*"},
+		"pqrs":                           []string{".qrs", "p.rs", "pq.s", "pqr."},
+		".*":                             []string{"asdklfj", "jasdfh", "asdhfajfh", "asdflkasdfjl"},
+		"d*":                             []string{"[abcd][abcd]", "d[a-z]+", ".....", "[d]*"},
+		"[a-p]+":                         []string{"[p-z]+", "apapapaapapapap", ".*", "abcdefgh*"},
+		"abcd[a-c]z+":                    []string{"abcd[b-d][yz]*", "abcdazzzz", "abcdbzzz", "abcdcz"},
+		".*\\\\":                         []string{".*", "asdfasdf\\\\"}, // Escaped \ character.
+		".a.a":                           []string{"b.b.", "c.c.", "d.d.", "e.e."},
 		".*.*.*.*.*.*.*.*.*.*.*.*.*.*.*": []string{".*.*.*.*.*.*.*.*.*.*.*"},
 		"foo.*bar":                       []string{"foobar", "fooalkdsjfbar"},
+		"[ab]+c":                         []string{"[bc]+", "[bc]*"},
 	}
 
 	for lhs, rhss := range tests {


### PR DESCRIPTION
First of, thanks for this package!  I was looking at some weird behaviour in OPA
rules and the rabbit hole ended up leading here.

The case `[ab]+c ~ [bc]+` was the smallest I was able to reproduce it down to.
The string `bc` is matched by both regexes, so there should be an intersection,
however `NonEmpty` returns `false`.

Digging into the code a bit, if we're comparing a plussed token on the left
hand side, and the first token on the right hand side matches, it seems
we always end up dropping that first token on the right hand side before
continuing.

This is not always acceptable though, consider the example `[ab]+c ~ [bc]+`. we
end up comparing `c` with the empty string in the second step.

In order to account for this, I introduced a second branch for the cases where
the first token on the right hand side maybe completely consume the the first
token on the left hand side (without eliminating itself).  This is only possible
if the token on the right hand side also has `+` or `*`, so AFAIK this doesn't
change the theoretical complexity.